### PR TITLE
fix misplaced name of code and $code

### DIFF
--- a/src/summernote-ext-highlight.js
+++ b/src/summernote-ext-highlight.js
@@ -85,11 +85,11 @@
 
             this.createCodeNode = function (code, select) {
                 var $code = $('<code>');
-                $code.html($code);
+                $code.html(code);
                 $code.addClass('language-' + select);
 
                 var $pre = $('<pre>');
-                $pre.html(code)
+                $pre.html($code)
                 $pre.addClass('prettyprint').addClass('linenums');
 
                 return $pre[0];


### PR DESCRIPTION
A bug in function this.createCodeNode.

This function is supposed to recieve variale code and put it in a &lt;code&gt; tag, then add the &lt;code&gt; tag to the &lt;pre&gt; tag.
However, the current code will give the following result:
```
<pre class="prettyprint linenums">Some code</pre>
```
The correct one should be this:
```
<pre class="prettyprint linenums"><code class="language-python">Some code</code></pre>
```
The problem is with the misplaced name of code and $code.